### PR TITLE
intel-microcode: upgrade 20251111 -> 20260210

### DIFF
--- a/recipes-core/microcode/intel-microcode_20260210.bb
+++ b/recipes-core/microcode/intel-microcode_20260210.bb
@@ -16,7 +16,7 @@ LIC_FILES_CHKSUM = "file://license;md5=d8405101ec6e90c1d84b082b0c40c721"
 SRC_URI = "git://github.com/intel/Intel-Linux-Processor-Microcode-Data-Files.git;protocol=https;branch=main \
            "
 
-SRCREV = "f910b0a225d66a23a407710c61b0b63ee612b50f"
+SRCREV = "439ddde999b07b28877a60e874f753e72ec2cd59"
 
 DEPENDS = "iucode-tool-native"
 


### PR DESCRIPTION
Update for functional issues. Refer to processor specification updates for details.

Updated Platforms:
  - Core Gen12
  - Core i3-N305/N300, N50/N97/N100/N200, Atom x7211E/x7213E/x7425E
  - Core Ultra Processor (Series 2) (ARL-H, ARL-S/HX (8P), ARL-U)
  - Atom C1100
  - Xeon Scalable Gen5
  - Xeon 6900/6700/6500 Series Processors with P-Cores
  - Xeon 6700P-B/6500P-B Series SoC with P-Cores
  - Xeon 6700/6500-Series Processors with P-Cores
  - Xeon D-17xx, D-27xx
  - Core Gen10 Mobile
  - Xeon Scalable Gen3
  - Core Ultra Processor
  - Core Gen11
  - Core Gen13/Gen14 (RPL-E/HX/S, RPL-S, RPL-HX/S)
  - Core Gen13 (RPL-H/P/PX 6+8, RPL-U 2+8)
  - Xeon Max
  - Xeon Scalable Gen4
  - Core Gen11 Mobile (TGL, TGL-H, TGL-R)
  - Core i3-N305/N300, N50/N97/N100/N200, Atom x7211E/x7213E/x7425E